### PR TITLE
Add machine-readable threat model (OTM 0.2.0)

### DIFF
--- a/.github/workflows/threat-model.yaml
+++ b/.github/workflows/threat-model.yaml
@@ -50,3 +50,5 @@ jobs:
       run: python3 -m pip install --quiet pyyaml jsonschema
     - name: Validate threat model
       run: python3 threat-model/validate.py
+    - name: Check diagrams are up to date
+      run: python3 threat-model/gen-diagram.py --check

--- a/.github/workflows/threat-model.yaml
+++ b/.github/workflows/threat-model.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Validates the machine-readable threat model (OTM 0.2.0) under threat-model/
+# against its JSON Schema and checks referential integrity.
+
+name: Threat Model
+
+on:
+  push:
+    branches: [ '*' ]
+    paths: [ 'threat-model/**' ]
+  pull_request:
+    branches: [ '*' ]
+    paths: [ 'threat-model/**' ]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate OTM
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Show the first log message
+      run: git log -n1
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install validator dependencies
+      run: python3 -m pip install --quiet pyyaml jsonschema
+    - name: Validate threat model
+      run: python3 threat-model/validate.py

--- a/pom.xml
+++ b/pom.xml
@@ -936,6 +936,8 @@ under the License.
               <exclude>.factorypath</exclude>
               <exclude>.github/**</exclude>
               <exclude>**/*.rf</exclude>
+              <!-- JSON does not support comments, so a license header cannot be embedded -->
+              <exclude>threat-model/*.json</exclude>
             </excludes>
           </configuration>
           <dependencies>

--- a/threat-model/DIAGRAMS.md
+++ b/threat-model/DIAGRAMS.md
@@ -1,0 +1,78 @@
+<!--
+  GENERATED FILE — do not edit by hand.
+  Regenerate with: python3 threat-model/gen-diagram.py
+-->
+# Threat Model Diagrams
+
+Data-flow diagrams generated from the OTM models. Node shapes: stadium = external entity, rounded = process, cylinder = datastore, hexagon = web application. Subgraphs are trust zones.
+
+## Apache Accumulo
+
+Source: [`accumulo.otm.yaml`](accumulo.otm.yaml)
+
+```mermaid
+flowchart LR
+  subgraph tz_public["Public / Client Network (trust 10)"]
+    client_app(["Client Application / Shell"])
+  end
+  subgraph tz_operator["Operator / Admin Network (trust 40)"]
+    monitor_user(["Operator (Browser / Admin CLI)"])
+  end
+  subgraph tz_cluster["Accumulo Server Cluster (trust 80)"]
+    manager("Manager")
+    tserver("Tablet Server")
+    scan_server("Scan Server (sserver)")
+    compactor("External Compactor")
+    gc("Garbage Collector")
+    monitor{{"Monitor (Web UI)"}}
+  end
+  subgraph tz_zookeeper["ZooKeeper Ensemble (trust 70)"]
+    zookeeper[("ZooKeeper Ensemble")]
+  end
+  subgraph tz_hdfs["HDFS Storage (trust 70)"]
+    hdfs[("HDFS (NameNode + DataNodes)")]
+  end
+
+  client_app -->|"Client RPC (scan / write / admin)"| tserver
+  client_app -->|"Client Eventual-Consistency Scan"| scan_server
+  client_app -->|"Client Admin RPC (create/drop, permissions)"| manager
+  manager -->|"Manager ⇄ TabletServer coordination"| tserver
+  manager -->|"Compaction dispatch (Coordinator ⇄ Compactor)"| compactor
+  tserver -->|"Server ⇄ ZooKeeper (locks, config, users)"| zookeeper
+  tserver -->|"Server ⇄ HDFS (RFile / WAL I/O)"| hdfs
+  compactor -->|"Compactor ⇄ HDFS (read/write RFiles)"| hdfs
+  gc -->|"GC ⇄ HDFS (delete unreferenced files)"| hdfs
+  monitor_user -->|"Operator → Monitor UI"| monitor
+```
+
+## Apache Accumulo — Column Visibility Subsystem
+
+Source: [`column-visibility.otm.yaml`](column-visibility.otm.yaml)
+
+```mermaid
+flowchart LR
+  subgraph tz_public["Public / Client Network (trust 10)"]
+    client_scan(["Scanning Client"])
+    client_writer(["Writing Client"])
+  end
+  subgraph tz_cluster["Accumulo Server Cluster (trust 80)"]
+    security_operation("SecurityOperation (auth gate)")
+    visibility_filter("System VisibilityFilter (per-cell evaluation)")
+    visibility_constraint("VisibilityConstraint (write gate)")
+    bulk_import("Bulk Import (externally-generated RFiles)")
+  end
+  subgraph tz_zookeeper["ZooKeeper Ensemble (trust 70)"]
+    zk_auth_store[("ZK Security Store (users / auths / perms)")]
+  end
+  subgraph tz_hdfs["HDFS Storage (trust 70)"]
+    rfile_store[("RFiles (cells + visibility labels)")]
+  end
+
+  client_scan -->|"Scan request with presented Authorizations"| security_operation
+  security_operation -->|"Look up user's granted authorizations / permissions"| zk_auth_store
+  security_operation -->|"Validated auths handed to per-cell filter"| visibility_filter
+  visibility_filter -->|"Read cells + ColumnVisibility labels"| rfile_store
+  client_writer -->|"Write mutation carrying a ColumnVisibility"| visibility_constraint
+  bulk_import -->|"Import externally-generated RFiles"| rfile_store
+```
+

--- a/threat-model/README.md
+++ b/threat-model/README.md
@@ -17,9 +17,13 @@ time, and validated in CI — instead of drifting in a wiki or diagram tool.
 | `column-visibility.otm.yaml` | Subsystem-depth model of the cell-level security data path (worked example of extending the skeleton). |
 | `accumulo.otm.schema.json` | JSON Schema (Draft 2020-12) for the OTM subset used here. |
 | `validate.py` | Validates structure **and** referential integrity for every `*.otm.yaml` model. |
+| `gen-diagram.py` | Generates Mermaid data-flow diagrams from the models. |
+| `DIAGRAMS.md` | Generated diagrams (GitHub renders Mermaid) — **do not edit by hand**. |
 
-CI validates every model on any change under `threat-model/` — see
-`.github/workflows/threat-model.yaml`.
+See **[DIAGRAMS.md](DIAGRAMS.md)** for the rendered data-flow diagrams.
+
+CI validates every model and checks the diagrams are up to date on any change
+under `threat-model/` — see `.github/workflows/threat-model.yaml`.
 
 ## Why OTM
 
@@ -76,6 +80,8 @@ To report a security vulnerability, follow the ASF process at
 
 ## Extending the model
 
-1. Edit `accumulo.otm.yaml` (add components/threats/mitigations, deepen a subsystem).
+1. Edit a model (add components/threats/mitigations, deepen a subsystem), or add
+   a new `*.otm.yaml`.
 2. Run `python3 threat-model/validate.py` until it passes.
-3. Open a PR — the model change is reviewed alongside the code change.
+3. Run `python3 threat-model/gen-diagram.py` to refresh `DIAGRAMS.md`.
+4. Open a PR — the model change is reviewed alongside the code change.

--- a/threat-model/README.md
+++ b/threat-model/README.md
@@ -1,0 +1,71 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+-->
+# Apache Accumulo — Machine-Readable Threat Model
+
+A version-controlled, machine-readable threat model for Accumulo (4.x / `main`).
+It lives next to the code so it can be reviewed in pull requests, diffed over
+time, and validated in CI — instead of drifting in a wiki or diagram tool.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `accumulo.otm.yaml` | The threat model itself, in [Open Threat Model (OTM) 0.2.0](https://github.com/iriusrisk/OpenThreatModel) format. |
+| `accumulo.otm.schema.json` | JSON Schema (Draft 2020-12) for the OTM subset used here. |
+| `validate.py` | Validates structure **and** referential integrity. |
+
+## Why OTM
+
+OTM is a tool-agnostic, declarative spec (plain YAML/JSON). It describes trust
+zones, components, dataflows, threats, and mitigations as data — so the model is
+readable by humans and by tooling (e.g. IriusRisk import, or custom scripts that
+generate diagrams or reports). No proprietary format, no binary diagrams.
+
+## Model structure
+
+- **trustZones** — trust boundaries with a `trustRating` (1 untrusted … 100 trusted):
+  public/client, operator, server cluster, ZooKeeper, HDFS.
+- **components** — processes and datastores: Manager, TabletServer, ScanServer,
+  Compactor, GC, Monitor, ZooKeeper, HDFS, plus external client/operator entities.
+  Each attaches the threats it is exposed to, with the mitigations addressing them.
+- **dataflows** — client RPC, inter-server coordination, ZooKeeper and HDFS I/O,
+  Monitor UI — tagged with protocol/auth (SASL, delegation tokens, TLS).
+- **threats** — STRIDE-categorized, with CWE references and a likelihood/impact
+  risk score.
+- **mitigations** — Accumulo's actual controls (column-visibility enforcement,
+  SASL/Kerberos, ZK ACLs, on-disk encryption, …), cross-referenced from threats.
+
+Threat/mitigation `state` fields (`exposed`, `partially-implemented`,
+`implemented`) make gaps explicit and reviewable.
+
+## Validate
+
+```bash
+# PyYAML required; jsonschema optional (adds structural validation)
+python3 -m pip install pyyaml jsonschema
+python3 threat-model/validate.py
+```
+
+`validate.py` checks the JSON Schema **and** referential integrity that a schema
+cannot express: every `component.parent`, dataflow `source`/`destination`, and
+threat/mitigation reference must resolve to a defined `id`. Orphan threats (not
+attached to any component) are reported as warnings.
+
+## Scope & status
+
+This is a **whole-system skeleton**: the major boundaries and a representative
+set of threats/mitigations are in place. It is intended to be extended
+per-subsystem over time (deeper RPC/auth, delegation tokens, column visibility,
+crypto, FATE, etc.). It is **not** a security audit or a completeness guarantee.
+
+To report a security vulnerability, follow the ASF process at
+<https://accumulo.apache.org/contact-us/> — do **not** use public issues.
+
+## Extending the model
+
+1. Edit `accumulo.otm.yaml` (add components/threats/mitigations, deepen a subsystem).
+2. Run `python3 threat-model/validate.py` until it passes.
+3. Open a PR — the model change is reviewed alongside the code change.

--- a/threat-model/README.md
+++ b/threat-model/README.md
@@ -13,9 +13,13 @@ time, and validated in CI — instead of drifting in a wiki or diagram tool.
 
 | File | Purpose |
 | --- | --- |
-| `accumulo.otm.yaml` | The threat model itself, in [Open Threat Model (OTM) 0.2.0](https://github.com/iriusrisk/OpenThreatModel) format. |
+| `accumulo.otm.yaml` | Whole-system threat model, in [Open Threat Model (OTM) 0.2.0](https://github.com/iriusrisk/OpenThreatModel) format. |
+| `column-visibility.otm.yaml` | Subsystem-depth model of the cell-level security data path (worked example of extending the skeleton). |
 | `accumulo.otm.schema.json` | JSON Schema (Draft 2020-12) for the OTM subset used here. |
-| `validate.py` | Validates structure **and** referential integrity. |
+| `validate.py` | Validates structure **and** referential integrity for every `*.otm.yaml` model. |
+
+CI validates every model on any change under `threat-model/` — see
+`.github/workflows/threat-model.yaml`.
 
 ## Why OTM
 
@@ -46,20 +50,26 @@ Threat/mitigation `state` fields (`exposed`, `partially-implemented`,
 ```bash
 # PyYAML required; jsonschema optional (adds structural validation)
 python3 -m pip install pyyaml jsonschema
-python3 threat-model/validate.py
+python3 threat-model/validate.py                       # all *.otm.yaml models
+python3 threat-model/validate.py threat-model/accumulo.otm.yaml   # one model
 ```
 
 `validate.py` checks the JSON Schema **and** referential integrity that a schema
 cannot express: every `component.parent`, dataflow `source`/`destination`, and
 threat/mitigation reference must resolve to a defined `id`. Orphan threats (not
-attached to any component) are reported as warnings.
+attached to any component) are reported as warnings. It runs in CI on every
+change under `threat-model/`.
 
 ## Scope & status
 
-This is a **whole-system skeleton**: the major boundaries and a representative
-set of threats/mitigations are in place. It is intended to be extended
-per-subsystem over time (deeper RPC/auth, delegation tokens, column visibility,
-crypto, FATE, etc.). It is **not** a security audit or a completeness guarantee.
+`accumulo.otm.yaml` is a **whole-system skeleton**: the major boundaries and a
+representative set of threats/mitigations. `column-visibility.otm.yaml` is a
+**worked example** of extending that skeleton to subsystem depth — the
+cell-level security data path, with threats/mitigations naming the real classes
+(`SecurityOperation`, `VisibilityEvaluator`, the system `VisibilityFilter`, the
+ZK security handlers). Further subsystems (RPC/auth, delegation tokens, crypto,
+FATE) can follow the same pattern. This is **not** a security audit or a
+completeness guarantee.
 
 To report a security vulnerability, follow the ASF process at
 <https://accumulo.apache.org/contact-us/> — do **not** use public issues.

--- a/threat-model/accumulo.otm.schema.json
+++ b/threat-model/accumulo.otm.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://accumulo.apache.org/threat-model/accumulo.otm.schema.json",
+  "title": "Open Threat Model (OTM) 0.2.0 — Accumulo subset",
+  "description": "Validation schema for the Accumulo OTM threat model. Covers the OTM 0.2.0 constructs used in this repo; permissive on optional vendor fields.",
+  "type": "object",
+  "required": ["otmVersion", "project"],
+  "additionalProperties": true,
+  "properties": {
+    "otmVersion": { "type": "string", "pattern": "^0\\.2\\.0$" },
+    "project": {
+      "type": "object",
+      "required": ["name", "id"],
+      "properties": {
+        "name": { "type": "string" },
+        "id": { "type": "string" },
+        "description": { "type": "string" },
+        "owner": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "representations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "id", "type"],
+        "properties": {
+          "name": { "type": "string" },
+          "id": { "type": "string" },
+          "type": { "type": "string", "enum": ["diagram", "code", "threat-model"] }
+        }
+      }
+    },
+    "trustZones": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "risk"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "risk": {
+            "type": "object",
+            "required": ["trustRating"],
+            "properties": {
+              "trustRating": { "type": "integer", "minimum": 1, "maximum": 100 }
+            }
+          },
+          "properties": { "type": "object" }
+        }
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "type", "parent"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "parent": {
+            "type": "object",
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+              "trustZone": { "type": "string" },
+              "component": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "threats": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["threat"],
+              "properties": {
+                "threat": { "type": "string" },
+                "state": { "type": "string" },
+                "mitigations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["mitigation"],
+                    "properties": {
+                      "mitigation": { "type": "string" },
+                      "state": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "dataflows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "source", "destination"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "source": { "type": "string" },
+          "destination": { "type": "string" },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "assets": {
+            "type": "object",
+            "properties": {
+              "processed": { "type": "array", "items": { "type": "string" } },
+              "stored": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "threats": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "categories": { "type": "array", "items": { "type": "string" } },
+          "cwes": { "type": "array", "items": { "type": "integer" } },
+          "risk": {
+            "type": "object",
+            "properties": {
+              "likelihood": { "type": "integer", "minimum": 0, "maximum": 100 },
+              "impact": { "type": "integer", "minimum": 0, "maximum": 100 }
+            }
+          }
+        }
+      }
+    },
+    "mitigations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "riskReduction": { "type": "integer", "minimum": 0, "maximum": 100 }
+        }
+      }
+    }
+  }
+}

--- a/threat-model/accumulo.otm.yaml
+++ b/threat-model/accumulo.otm.yaml
@@ -1,0 +1,491 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Apache Accumulo — Machine-Readable Threat Model
+# Format: Open Threat Model (OTM) v0.2.0  — https://github.com/iriusrisk/OpenThreatModel
+# Scope:  Whole-system skeleton for the 4.x (main) line.
+#
+# This is a SKELETON: trust zones, components, dataflows and a representative
+# set of STRIDE-derived threats + mitigations are in place. Threats are marked
+# with a `state` and cross-referenced to mitigations so gaps are visible.
+# Extend per-subsystem over time. Validate with the JSON Schema in this dir.
+
+otmVersion: "0.2.0"
+
+project:
+  name: Apache Accumulo
+  id: apache-accumulo
+  description: >-
+    Distributed, sorted key/value store built on Apache Hadoop (HDFS) and Apache
+    ZooKeeper. Provides cell-level security via column visibility labels,
+    pluggable authentication/authorization, SASL/Kerberos wire security,
+    delegation tokens, and optional on-disk encryption of RFiles and WALs.
+  owner: Apache Accumulo PMC
+  tags:
+    - line:4.x
+    - branch:main
+
+# ---------------------------------------------------------------------------
+# Representations — how this model can be viewed/rendered
+# ---------------------------------------------------------------------------
+representations:
+  - name: Accumulo Deployment (logical)
+    id: accumulo-logical
+    type: diagram
+
+# ---------------------------------------------------------------------------
+# Trust Zones — trustRating: 100 = fully trusted, 1 = fully untrusted
+# ---------------------------------------------------------------------------
+trustZones:
+  - id: tz-public
+    name: Public / Client Network
+    risk:
+      trustRating: 10
+    properties:
+      description: >-
+        Where end-user client applications and interactive shells run. Outside
+        the cluster security perimeter; authenticates inbound to the cluster.
+
+  - id: tz-operator
+    name: Operator / Admin Network
+    risk:
+      trustRating: 40
+    properties:
+      description: >-
+        Administrators, dashboards and browsers reaching the Monitor UI and
+        running admin CLIs (accumulo admin, init, config).
+
+  - id: tz-cluster
+    name: Accumulo Server Cluster
+    risk:
+      trustRating: 80
+    properties:
+      description: >-
+        Mutually-authenticating Accumulo server processes on the internal
+        cluster network. Trusted, but breachable via a single compromised node.
+
+  - id: tz-zookeeper
+    name: ZooKeeper Ensemble
+    risk:
+      trustRating: 70
+    properties:
+      description: >-
+        Stores instance metadata, locks, config, users, permissions, and the
+        delegation-token master keys. High-value target.
+
+  - id: tz-hdfs
+    name: HDFS Storage
+    risk:
+      trustRating: 70
+    properties:
+      description: >-
+        Durable storage for RFiles (table data) and write-ahead logs (WALs).
+        Data at rest lives here.
+
+# ---------------------------------------------------------------------------
+# Components
+# ---------------------------------------------------------------------------
+components:
+
+  - id: client-app
+    name: Client Application / Shell
+    type: external-entity
+    parent:
+      trustZone: tz-public
+    tags: [thrift-client, accumulo-shell]
+
+  - id: monitor-user
+    name: Operator (Browser / Admin CLI)
+    type: external-entity
+    parent:
+      trustZone: tz-operator
+
+  - id: manager
+    name: Manager
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [coordination, fate, tablet-assignment, compaction-coordinator]
+    threats:
+      - threat: t-zk-acl-weak
+        state: exposed
+        mitigations:
+          - mitigation: m-zk-kerberos-acl
+            state: partially-implemented
+      - threat: t-fate-privileged-op
+        state: exposed
+        mitigations:
+          - mitigation: m-authz-permission-check
+            state: implemented
+
+  - id: tserver
+    name: Tablet Server
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [read, write, wal, visibility-enforcement]
+    threats:
+      - threat: t-visibility-bypass
+        state: exposed
+        mitigations:
+          - mitigation: m-visibility-enforcement
+            state: implemented
+      - threat: t-unauth-rpc
+        state: exposed
+        mitigations:
+          - mitigation: m-sasl-mutual-auth
+            state: partially-implemented
+      - threat: t-authz-cache-stale
+        state: exposed
+        mitigations:
+          - mitigation: m-authz-permission-check
+            state: implemented
+
+  - id: scan-server
+    name: Scan Server (sserver)
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [eventual-consistency-scan, elasticity]
+    threats:
+      - threat: t-visibility-bypass
+        state: exposed
+        mitigations:
+          - mitigation: m-visibility-enforcement
+            state: implemented
+
+  - id: compactor
+    name: External Compactor
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [external-compaction, elasticity]
+    threats:
+      - threat: t-crypto-key-exposure
+        state: exposed
+        mitigations:
+          - mitigation: m-ondisk-encryption
+            state: partially-implemented
+
+  - id: gc
+    name: Garbage Collector
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [file-deletion]
+    threats:
+      - threat: t-gc-destructive-delete
+        state: exposed
+        mitigations:
+          - mitigation: m-authz-permission-check
+            state: implemented
+
+  - id: monitor
+    name: Monitor (Web UI)
+    type: web-application
+    parent:
+      trustZone: tz-cluster
+    tags: [metrics, web-ui, rest]
+    threats:
+      - threat: t-monitor-info-disclosure
+        state: exposed
+        mitigations:
+          - mitigation: m-monitor-tls-auth
+            state: partially-implemented
+
+  - id: zookeeper
+    name: ZooKeeper Ensemble
+    type: datastore
+    parent:
+      trustZone: tz-zookeeper
+    tags: [metadata, locks, users, permissions, delegation-token-keys]
+    threats:
+      - threat: t-zk-acl-weak
+        state: exposed
+        mitigations:
+          - mitigation: m-zk-kerberos-acl
+            state: partially-implemented
+      - threat: t-deleg-token-key-theft
+        state: exposed
+        mitigations:
+          - mitigation: m-zk-kerberos-acl
+            state: partially-implemented
+
+  - id: hdfs
+    name: HDFS (NameNode + DataNodes)
+    type: datastore
+    parent:
+      trustZone: tz-hdfs
+    tags: [rfile, wal, data-at-rest]
+    threats:
+      - threat: t-hdfs-file-tampering
+        state: exposed
+        mitigations:
+          - mitigation: m-ondisk-encryption
+            state: partially-implemented
+          - mitigation: m-hdfs-perms
+            state: implemented
+
+# ---------------------------------------------------------------------------
+# Dataflows
+# ---------------------------------------------------------------------------
+dataflows:
+  - id: df-client-rpc
+    name: Client RPC (scan / write / admin)
+    source: client-app
+    destination: tserver
+    tags: [thrift, sasl, delegation-token]
+    assets:
+      processed: [cell-data, authorizations, credentials]
+
+  - id: df-client-scanserver
+    name: Client Eventual-Consistency Scan
+    source: client-app
+    destination: scan-server
+    tags: [thrift, sasl]
+    assets:
+      processed: [cell-data, authorizations]
+
+  - id: df-client-manager
+    name: Client Admin RPC (create/drop, permissions)
+    source: client-app
+    destination: manager
+    tags: [thrift, sasl]
+    assets:
+      processed: [credentials, permissions]
+
+  - id: df-manager-tserver
+    name: Manager ⇄ TabletServer coordination
+    source: manager
+    destination: tserver
+    tags: [thrift, sasl, internal]
+
+  - id: df-manager-compactor
+    name: Compaction dispatch (Coordinator ⇄ Compactor)
+    source: manager
+    destination: compactor
+    tags: [thrift, sasl, external-compaction]
+
+  - id: df-server-zk
+    name: Server ⇄ ZooKeeper (locks, config, users)
+    source: tserver
+    destination: zookeeper
+    tags: [zk-client, sasl-optional]
+    assets:
+      processed: [credentials, permissions, delegation-token-keys]
+
+  - id: df-server-hdfs
+    name: Server ⇄ HDFS (RFile / WAL I/O)
+    source: tserver
+    destination: hdfs
+    tags: [hdfs-client, hadoop-delegation-token]
+    assets:
+      stored: [cell-data]
+
+  - id: df-compactor-hdfs
+    name: Compactor ⇄ HDFS (read/write RFiles)
+    source: compactor
+    destination: hdfs
+    tags: [hdfs-client]
+    assets:
+      stored: [cell-data]
+
+  - id: df-gc-hdfs
+    name: GC ⇄ HDFS (delete unreferenced files)
+    source: gc
+    destination: hdfs
+    tags: [hdfs-client, destructive]
+
+  - id: df-operator-monitor
+    name: Operator → Monitor UI
+    source: monitor-user
+    destination: monitor
+    tags: [http, https-optional]
+    assets:
+      processed: [operational-metadata]
+
+# ---------------------------------------------------------------------------
+# Threats  (categories use STRIDE)
+# ---------------------------------------------------------------------------
+threats:
+  - id: t-visibility-bypass
+    name: Column-visibility label bypass / data exfiltration
+    description: >-
+      A client reads cells they are not authorized to see because visibility
+      labels are not evaluated, are evaluated against forged authorizations, or
+      a scan/scan-server path skips enforcement.
+    categories: [information-disclosure, elevation-of-privilege]
+    cwes: [285, 863]
+    risk:
+      likelihood: 40
+      impact: 90
+
+  - id: t-unauth-rpc
+    name: Unauthenticated / spoofed cluster RPC
+    description: >-
+      An attacker on the cluster network invokes Thrift RPCs without valid SASL
+      credentials, or impersonates another server, when wire auth is disabled or
+      misconfigured (non-Kerberos deployments).
+    categories: [spoofing, elevation-of-privilege]
+    cwes: [287, 306]
+    risk:
+      likelihood: 40
+      impact: 80
+
+  - id: t-deleg-token-key-theft
+    name: Delegation-token master key theft
+    description: >-
+      Reading the delegation-token secret keys from ZooKeeper allows minting
+      valid delegation tokens and impersonating any user.
+    categories: [spoofing, elevation-of-privilege]
+    cwes: [522, 320]
+    risk:
+      likelihood: 20
+      impact: 95
+
+  - id: t-zk-acl-weak
+    name: Weak ZooKeeper ACLs expose secrets/metadata
+    description: >-
+      ZooKeeper znodes holding users, permissions, config and token keys are
+      world-readable or lack Kerberos ACLs, exposing credentials and allowing
+      metadata tampering.
+    categories: [information-disclosure, tampering]
+    cwes: [732, 284]
+    risk:
+      likelihood: 30
+      impact: 85
+
+  - id: t-hdfs-file-tampering
+    name: Direct RFile / WAL tampering or read in HDFS
+    description: >-
+      A principal with HDFS access reads or modifies RFiles/WALs directly,
+      bypassing Accumulo's visibility and authorization layer entirely.
+    categories: [tampering, information-disclosure]
+    cwes: [732, 284]
+    risk:
+      likelihood: 30
+      impact: 90
+
+  - id: t-crypto-key-exposure
+    name: On-disk encryption key exposure / weak crypto config
+    description: >-
+      Table encryption keys are stored or transmitted insecurely, or encryption
+      is disabled, leaving data-at-rest readable if HDFS is compromised.
+    categories: [information-disclosure]
+    cwes: [311, 320]
+    risk:
+      likelihood: 30
+      impact: 80
+
+  - id: t-authz-cache-stale
+    name: Stale authorization / permission cache
+    description: >-
+      Revoked permissions or authorizations remain effective due to cached
+      values on tservers until TTL expiry, extending an attacker's access.
+    categories: [elevation-of-privilege]
+    cwes: [613, 863]
+    risk:
+      likelihood: 30
+      impact: 50
+
+  - id: t-fate-privileged-op
+    name: Unauthorized FATE administrative operation
+    description: >-
+      A client triggers a privileged FATE operation (drop/rename table, alter
+      permissions) without holding the required system/namespace/table permission.
+    categories: [elevation-of-privilege, tampering]
+    cwes: [285, 862]
+    risk:
+      likelihood: 20
+      impact: 75
+
+  - id: t-gc-destructive-delete
+    name: Garbage Collector deletes referenced files (data loss)
+    description: >-
+      A bug or manipulated metadata causes the GC to delete still-referenced
+      RFiles/WALs, or a forged candidate list drives destructive deletion.
+    categories: [tampering, denial-of-service]
+    cwes: [284, 707]
+    risk:
+      likelihood: 15
+      impact: 85
+
+  - id: t-monitor-info-disclosure
+    name: Monitor UI information disclosure
+    description: >-
+      The Monitor web UI/REST endpoints expose table names, scan data samples,
+      configuration and metrics without TLS or authentication.
+    categories: [information-disclosure]
+    cwes: [200, 306]
+    risk:
+      likelihood: 45
+      impact: 45
+
+# ---------------------------------------------------------------------------
+# Mitigations
+# ---------------------------------------------------------------------------
+mitigations:
+  - id: m-visibility-enforcement
+    name: Server-side column-visibility enforcement
+    description: >-
+      Every scan filters cells against the caller's Authorizations using the
+      ColumnVisibility evaluator, enforced on tserver and scan-server read paths.
+    riskReduction: 80
+
+  - id: m-sasl-mutual-auth
+    name: SASL/Kerberos mutual authentication + wire encryption
+    description: >-
+      Enable instance.rpc.sasl.enabled with Kerberos so all cluster RPC is
+      mutually authenticated and optionally encrypted (QOP auth-conf).
+    riskReduction: 75
+
+  - id: m-authz-permission-check
+    name: Pluggable authorizer permission checks
+    description: >-
+      System/namespace/table permission checks on every privileged operation via
+      the configured Authorizer/PermissionHandler.
+    riskReduction: 70
+
+  - id: m-zk-kerberos-acl
+    name: Kerberos-authenticated ZooKeeper ACLs
+    description: >-
+      Restrict sensitive znodes (users, permissions, token keys) with
+      Kerberos/SASL ACLs so only cluster principals can read/write them.
+    riskReduction: 70
+
+  - id: m-ondisk-encryption
+    name: On-disk encryption of RFiles and WALs
+    description: >-
+      Configure the crypto service to encrypt table files and write-ahead logs
+      at rest with a securely-managed key encryption key.
+    riskReduction: 70
+
+  - id: m-hdfs-perms
+    name: Restrictive HDFS permissions + Hadoop delegation tokens
+    description: >-
+      Accumulo's HDFS directories are readable/writable only by the service
+      principal; access uses Hadoop delegation tokens.
+    riskReduction: 60
+
+  - id: m-monitor-tls-auth
+    name: Monitor TLS + authentication
+    description: >-
+      Serve the Monitor over HTTPS and require authentication; do not expose it
+      to untrusted networks.
+    riskReduction: 60

--- a/threat-model/column-visibility.otm.yaml
+++ b/threat-model/column-visibility.otm.yaml
@@ -1,0 +1,418 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Apache Accumulo — Column Visibility / Cell-Level Security (deep subsystem model)
+# Format: Open Threat Model (OTM) v0.2.0
+#
+# Focused model of the data path that enforces cell-level security: how a scan's
+# Authorizations are validated and how per-cell ColumnVisibility labels are
+# evaluated so a caller only ever sees cells they are entitled to. This is the
+# subsystem-depth companion to accumulo.otm.yaml (the whole-system skeleton).
+#
+# Key implementation references (4.x / main):
+#   core   org.apache.accumulo.core.security.ColumnVisibility
+#   core   org.apache.accumulo.core.security.VisibilityEvaluator
+#   core   org.apache.accumulo.core.security.Authorizations
+#   core   org.apache.accumulo.core.iteratorsImpl.system.VisibilityFilter
+#   server org.apache.accumulo.server.security.SecurityOperation
+#   server org.apache.accumulo.server.security.AuditedSecurityOperation
+#   server org.apache.accumulo.server.security.handler.ZKAuthenticator
+#   server org.apache.accumulo.server.security.handler.ZKAuthorizor
+#   server org.apache.accumulo.server.security.handler.ZKPermHandler
+
+otmVersion: "0.2.0"
+
+project:
+  name: Apache Accumulo — Column Visibility Subsystem
+  id: apache-accumulo-column-visibility
+  description: >-
+    Cell-level security data path: validation of a scan's presented
+    Authorizations against the user's granted labels, and per-cell evaluation of
+    ColumnVisibility expressions by the system VisibilityFilter, plus the write
+    path constraint that governs which labels a writer may apply.
+  owner: Apache Accumulo PMC
+  tags:
+    - subsystem:column-visibility
+    - line:4.x
+
+representations:
+  - name: Cell-level security data path
+    id: cv-dataflow
+    type: diagram
+
+trustZones:
+  - id: tz-public
+    name: Public / Client Network
+    risk:
+      trustRating: 10
+  - id: tz-cluster
+    name: Accumulo Server Cluster
+    risk:
+      trustRating: 80
+  - id: tz-zookeeper
+    name: ZooKeeper Ensemble
+    risk:
+      trustRating: 70
+  - id: tz-hdfs
+    name: HDFS Storage
+    risk:
+      trustRating: 70
+
+components:
+
+  - id: client-scan
+    name: Scanning Client
+    type: external-entity
+    parent:
+      trustZone: tz-public
+    tags: [scan, presents-authorizations]
+    threats:
+      - threat: t-cv-forged-auths
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-auth-subset-check
+            state: implemented
+
+  - id: client-writer
+    name: Writing Client
+    type: external-entity
+    parent:
+      trustZone: tz-public
+    tags: [mutation, sets-columnvisibility]
+    threats:
+      - threat: t-cv-empty-visibility
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-write-constraint
+            state: partially-implemented
+      - threat: t-cv-write-unheld-label
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-write-constraint
+            state: partially-implemented
+
+  - id: security-operation
+    name: SecurityOperation (auth gate)
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [canScan, authenticatedUserHasAuthorizations, AuditedSecurityOperation]
+    threats:
+      - threat: t-cv-forged-auths
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-auth-subset-check
+            state: implemented
+          - mitigation: m-cv-audit
+            state: implemented
+      - threat: t-cv-stale-auth-cache
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-cache-ttl
+            state: implemented
+
+  - id: visibility-filter
+    name: System VisibilityFilter (per-cell evaluation)
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [VisibilityEvaluator, ColumnVisibility, scan-iterator]
+    threats:
+      - threat: t-cv-filter-bypass
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-system-filter-nonremovable
+            state: implemented
+      - threat: t-cv-expr-parsing
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-expr-hardening
+            state: partially-implemented
+      - threat: t-cv-combiner-leak
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-system-filter-nonremovable
+            state: partially-implemented
+
+  - id: visibility-constraint
+    name: VisibilityConstraint (write gate)
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [write-path, constraint]
+    threats:
+      - threat: t-cv-write-unheld-label
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-write-constraint
+            state: partially-implemented
+
+  - id: zk-auth-store
+    name: ZK Security Store (users / auths / perms)
+    type: datastore
+    parent:
+      trustZone: tz-zookeeper
+    tags: [ZKAuthenticator, ZKAuthorizor, ZKPermHandler]
+    threats:
+      - threat: t-cv-zk-auth-tamper
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-zk-acl
+            state: partially-implemented
+
+  - id: rfile-store
+    name: RFiles (cells + visibility labels)
+    type: datastore
+    parent:
+      trustZone: tz-hdfs
+    tags: [rfile, columnvisibility-at-rest]
+    threats:
+      - threat: t-cv-bulk-unlabeled
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-bulk-validation
+            state: partially-implemented
+
+  - id: bulk-import
+    name: Bulk Import (externally-generated RFiles)
+    type: process
+    parent:
+      trustZone: tz-cluster
+    tags: [importDirectory, external-rfiles]
+    threats:
+      - threat: t-cv-bulk-unlabeled
+        state: exposed
+        mitigations:
+          - mitigation: m-cv-bulk-validation
+            state: partially-implemented
+
+dataflows:
+  - id: df-cv-scan-request
+    name: Scan request with presented Authorizations
+    source: client-scan
+    destination: security-operation
+    tags: [thrift, sasl]
+    assets:
+      processed: [authorizations, credentials]
+
+  - id: df-cv-auth-lookup
+    name: Look up user's granted authorizations / permissions
+    source: security-operation
+    destination: zk-auth-store
+    tags: [zk-client]
+    assets:
+      processed: [granted-authorizations, permissions]
+
+  - id: df-cv-validated-scan
+    name: Validated auths handed to per-cell filter
+    source: security-operation
+    destination: visibility-filter
+    tags: [internal]
+    assets:
+      processed: [authorizations]
+
+  - id: df-cv-read-cells
+    name: Read cells + ColumnVisibility labels
+    source: visibility-filter
+    destination: rfile-store
+    tags: [hdfs-client]
+    assets:
+      stored: [cell-data, columnvisibility]
+
+  - id: df-cv-write-mutation
+    name: Write mutation carrying a ColumnVisibility
+    source: client-writer
+    destination: visibility-constraint
+    tags: [thrift, sasl]
+    assets:
+      processed: [cell-data, columnvisibility]
+
+  - id: df-cv-bulk-import
+    name: Import externally-generated RFiles
+    source: bulk-import
+    destination: rfile-store
+    tags: [hdfs, bulk]
+    assets:
+      stored: [cell-data, columnvisibility]
+
+threats:
+  - id: t-cv-forged-auths
+    name: Scan presents authorizations the user does not hold
+    description: >-
+      A client requests a scan with an Authorizations set broader than the
+      labels granted to its authenticated user, attempting to read cells above
+      its clearance.
+    categories: [elevation-of-privilege, information-disclosure]
+    cwes: [863, 285]
+    risk:
+      likelihood: 45
+      impact: 90
+
+  - id: t-cv-filter-bypass
+    name: System VisibilityFilter removed or bypassed by iterator config
+    description: >-
+      A custom server-side iterator configuration, or a scan path that omits the
+      system VisibilityFilter, returns cells without evaluating their
+      ColumnVisibility against the caller's authorizations.
+    categories: [elevation-of-privilege, information-disclosure]
+    cwes: [284, 693]
+    risk:
+      likelihood: 25
+      impact: 90
+
+  - id: t-cv-expr-parsing
+    name: ColumnVisibility expression parsing edge cases
+    description: >-
+      Malformed, adversarial, or ambiguous ColumnVisibility expressions cause
+      the evaluator to mis-evaluate (fail-open) or throw in a way that changes
+      visibility semantics.
+    categories: [tampering, information-disclosure]
+    cwes: [20, 703]
+    risk:
+      likelihood: 20
+      impact: 70
+
+  - id: t-cv-empty-visibility
+    name: Cells written with empty visibility are visible to everyone
+    description: >-
+      A writer omits a ColumnVisibility (empty label), so the cell is readable by
+      any scan regardless of authorizations — often unintended data exposure.
+    categories: [information-disclosure]
+    cwes: [732, 1188]
+    risk:
+      likelihood: 50
+      impact: 70
+
+  - id: t-cv-write-unheld-label
+    name: Writer applies a visibility label it does not hold
+    description: >-
+      Without the visibility constraint, a user writes cells labeled with a
+      ColumnVisibility they themselves cannot satisfy, hiding data from
+      legitimate readers or planting mislabeled cells.
+    categories: [tampering, repudiation]
+    cwes: [285, 345]
+    risk:
+      likelihood: 30
+      impact: 60
+
+  - id: t-cv-bulk-unlabeled
+    name: Bulk-imported RFiles contain unintended / empty visibility
+    description: >-
+      Externally-generated RFiles imported via bulk import carry cells whose
+      ColumnVisibility was set incorrectly or left empty, injecting
+      over-visible data that bypasses normal write-path checks.
+    categories: [tampering, information-disclosure]
+    cwes: [345, 20]
+    risk:
+      likelihood: 30
+      impact: 75
+
+  - id: t-cv-stale-auth-cache
+    name: Revoked authorizations remain effective (cache staleness)
+    description: >-
+      After an administrator revokes a label from a user, cached authorization
+      data on the server keeps honoring the revoked label until TTL expiry.
+    categories: [elevation-of-privilege]
+    cwes: [613, 863]
+    risk:
+      likelihood: 35
+      impact: 55
+
+  - id: t-cv-zk-auth-tamper
+    name: Tampering the granted-authorizations store in ZooKeeper
+    description: >-
+      An attacker with write access to the ZK security znodes grants a user
+      additional authorization labels, elevating what that user can see.
+    categories: [tampering, elevation-of-privilege]
+    cwes: [732, 284]
+    risk:
+      likelihood: 20
+      impact: 90
+
+  - id: t-cv-combiner-leak
+    name: Server-side combiner merges cells across visibilities
+    description: >-
+      A combiner/aggregating iterator merges values from cells with different
+      ColumnVisibility labels, producing a result that leaks higher-visibility
+      data into a lower-visibility cell.
+    categories: [information-disclosure]
+    cwes: [200, 863]
+    risk:
+      likelihood: 25
+      impact: 70
+
+mitigations:
+  - id: m-cv-auth-subset-check
+    name: Scan authorizations must be a subset of granted authorizations
+    description: >-
+      SecurityOperation.authenticatedUserHasAuthorizations rejects any scan whose
+      presented Authorizations exceed the labels granted to the authenticated
+      user, before results are produced.
+    riskReduction: 85
+
+  - id: m-cv-system-filter-nonremovable
+    name: Non-removable system VisibilityFilter on every scan
+    description: >-
+      The system VisibilityFilter (VisibilityEvaluator) is applied on every read
+      so per-cell ColumnVisibility is always evaluated against the scan's
+      authorizations, independent of user-configured iterators.
+    riskReduction: 85
+
+  - id: m-cv-write-constraint
+    name: VisibilityConstraint on the write path
+    description: >-
+      When configured, VisibilityConstraint rejects mutations bearing a
+      ColumnVisibility the writer cannot satisfy, and can flag empty-visibility
+      writes for review.
+    riskReduction: 60
+
+  - id: m-cv-expr-hardening
+    name: Strict ColumnVisibility parsing / evaluation
+    description: >-
+      Fail-closed parsing and evaluation of ColumnVisibility expressions, with
+      test coverage for malformed and adversarial expressions.
+    riskReduction: 60
+
+  - id: m-cv-zk-acl
+    name: Kerberos-authenticated ACLs on ZK security store
+    description: >-
+      Restrict the ZKAuthorizor/ZKPermHandler znodes with Kerberos/SASL ACLs so
+      only cluster principals can read or modify granted authorizations.
+    riskReduction: 70
+
+  - id: m-cv-audit
+    name: Audited authorization decisions
+    description: >-
+      AuditedSecurityOperation records authorization checks, enabling detection
+      of attempts to scan with unheld authorizations.
+    riskReduction: 40
+
+  - id: m-cv-cache-ttl
+    name: Bounded authorization cache TTL
+    description: >-
+      A short, bounded TTL on cached authorizations limits how long a revoked
+      label stays effective.
+    riskReduction: 50
+
+  - id: m-cv-bulk-validation
+    name: Validate visibility on bulk import
+    description: >-
+      Verify/label cells during bulk import so externally-generated RFiles cannot
+      inject over-visible cells into a table.
+    riskReduction: 55

--- a/threat-model/gen-diagram.py
+++ b/threat-model/gen-diagram.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Generate Mermaid data-flow diagrams from the OTM threat models.
+
+Renders each *.otm.yaml as a Mermaid flowchart: trust zones become subgraphs,
+components become shaped nodes (external entity / process / datastore / web app),
+and dataflows become labelled edges. GitHub renders Mermaid in Markdown, so the
+output drops straight into DIAGRAMS.md.
+
+Usage:
+    python3 threat-model/gen-diagram.py            # regenerate DIAGRAMS.md
+    python3 threat-model/gen-diagram.py --check     # fail if DIAGRAMS.md is stale
+
+Requires PyYAML.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+OUT = HERE / "DIAGRAMS.md"
+
+# Node shape per OTM component type: (open, close) Mermaid delimiters.
+SHAPES = {
+    "external-entity": ("([", "])"),   # stadium
+    "process": ("(", ")"),             # rounded
+    "datastore": ("[(", ")]"),         # cylinder
+    "web-application": ("{{", "}}"),   # hexagon
+}
+DEFAULT_SHAPE = ("[", "]")
+
+
+def load_yaml(path: Path):
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        sys.exit("ERROR: PyYAML is required (pip install pyyaml)")
+    with path.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def nid(raw: str) -> str:
+    """Mermaid-safe node id."""
+    return raw.replace("-", "_")
+
+
+def esc(text: str) -> str:
+    """Escape a label for a Mermaid node/edge."""
+    return text.replace('"', "&quot;").replace("\n", " ").strip()
+
+
+def render(model: dict) -> str:
+    zones = {z["id"]: z for z in model.get("trustZones", [])}
+    comps = model.get("components", [])
+    by_zone: dict[str, list[dict]] = {zid: [] for zid in zones}
+    orphans: list[dict] = []
+    for c in comps:
+        zid = c.get("parent", {}).get("trustZone")
+        (by_zone.get(zid, orphans) if zid in zones else orphans).append(c)
+
+    lines = ["flowchart LR"]
+
+    for zid, zone in zones.items():
+        rating = zone.get("risk", {}).get("trustRating", "?")
+        title = esc(f'{zone["name"]} (trust {rating})')
+        lines.append(f'  subgraph {nid(zid)}["{title}"]')
+        for c in by_zone[zid]:
+            o, cl = SHAPES.get(c.get("type", ""), DEFAULT_SHAPE)
+            lines.append(f'    {nid(c["id"])}{o}"{esc(c["name"])}"{cl}')
+        lines.append("  end")
+
+    for c in orphans:
+        o, cl = SHAPES.get(c.get("type", ""), DEFAULT_SHAPE)
+        lines.append(f'  {nid(c["id"])}{o}"{esc(c["name"])}"{cl}')
+
+    lines.append("")
+    for d in model.get("dataflows", []):
+        label = esc(d.get("name", ""))
+        lines.append(f'  {nid(d["source"])} -->|"{label}"| {nid(d["destination"])}')
+
+    return "\n".join(lines)
+
+
+def build_doc() -> str:
+    models = sorted(HERE.glob("*.otm.yaml"))
+    parts = [
+        "<!--",
+        "  GENERATED FILE — do not edit by hand.",
+        "  Regenerate with: python3 threat-model/gen-diagram.py",
+        "-->",
+        "# Threat Model Diagrams",
+        "",
+        "Data-flow diagrams generated from the OTM models. Node shapes: "
+        "stadium = external entity, rounded = process, cylinder = datastore, "
+        "hexagon = web application. Subgraphs are trust zones.",
+        "",
+    ]
+    for path in models:
+        model = load_yaml(path)
+        parts += [
+            f"## {model['project']['name']}",
+            "",
+            f"Source: [`{path.name}`]({path.name})",
+            "",
+            "```mermaid",
+            render(model),
+            "```",
+            "",
+        ]
+    return "\n".join(parts) + "\n"
+
+
+def main() -> int:
+    doc = build_doc()
+    if "--check" in sys.argv[1:]:
+        current = OUT.read_text() if OUT.exists() else ""
+        if current != doc:
+            print("STALE: DIAGRAMS.md is out of date — run gen-diagram.py")
+            return 1
+        print("OK — DIAGRAMS.md is up to date.")
+        return 0
+    OUT.write_text(doc)
+    print(f"Wrote {OUT.name} ({len(doc.splitlines())} lines).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/threat-model/validate.py
+++ b/threat-model/validate.py
@@ -26,7 +26,7 @@ Two layers:
      must resolve to a defined id.
 
 Usage:
-    python3 threat-model/validate.py            # validate default model
+    python3 threat-model/validate.py            # validate every *.otm.yaml here
     python3 threat-model/validate.py path.yaml  # validate a specific file
 
 Exit code 0 = valid, 1 = problems found. Requires PyYAML; jsonschema optional.
@@ -38,7 +38,6 @@ import sys
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-DEFAULT_MODEL = HERE / "accumulo.otm.yaml"
 SCHEMA = HERE / "accumulo.otm.schema.json"
 
 
@@ -108,10 +107,10 @@ def ref_validate(model, errors: list[str]) -> None:
         print(f"WARN: threat '{orphan}' is defined but not attached to any component")
 
 
-def main() -> int:
-    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_MODEL
+def validate_one(path: Path) -> bool:
     if not path.exists():
-        sys.exit(f"ERROR: model not found: {path}")
+        print(f"ERROR: model not found: {path}")
+        return False
     model = load_yaml(path)
 
     errors: list[str] = []
@@ -119,15 +118,27 @@ def main() -> int:
     ref_validate(model, errors)
 
     if errors:
-        print(f"\nFAILED — {len(errors)} problem(s):")
+        print(f"\nFAILED — {path.name}: {len(errors)} problem(s):")
         for e in errors:
             print(f"  - {e}")
-        return 1
+        return False
     print(f"OK — {path.name} is valid "
           f"({len(model.get('components', []))} components, "
           f"{len(model.get('threats', []))} threats, "
           f"{len(model.get('mitigations', []))} mitigations).")
-    return 0
+    return True
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        paths = [Path(a) for a in sys.argv[1:]]
+    else:
+        paths = sorted(HERE.glob("*.otm.yaml"))
+    if not paths:
+        sys.exit("ERROR: no *.otm.yaml models found")
+
+    ok = all(validate_one(p) for p in paths)
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/threat-model/validate.py
+++ b/threat-model/validate.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Validate the Accumulo OTM threat model.
+
+Two layers:
+  1. JSON Schema structural validation (if `jsonschema` is installed).
+  2. Referential-integrity checks that a schema cannot express: every
+     component.parent, dataflow endpoint, and threat/mitigation reference
+     must resolve to a defined id.
+
+Usage:
+    python3 threat-model/validate.py            # validate default model
+    python3 threat-model/validate.py path.yaml  # validate a specific file
+
+Exit code 0 = valid, 1 = problems found. Requires PyYAML; jsonschema optional.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_MODEL = HERE / "accumulo.otm.yaml"
+SCHEMA = HERE / "accumulo.otm.schema.json"
+
+
+def load_yaml(path: Path):
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        sys.exit("ERROR: PyYAML is required (pip install pyyaml)")
+    with path.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def schema_validate(model, errors: list[str]) -> None:
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        print("NOTE: jsonschema not installed — skipping structural validation.")
+        return
+    schema = json.loads(SCHEMA.read_text())
+    validator = jsonschema.Draft202012Validator(schema)
+    for err in sorted(validator.iter_errors(model), key=lambda e: e.path):
+        loc = "/".join(str(p) for p in err.path) or "<root>"
+        errors.append(f"[schema] {loc}: {err.message}")
+
+
+def ids(items) -> set[str]:
+    return {i["id"] for i in (items or []) if isinstance(i, dict) and "id" in i}
+
+
+def ref_validate(model, errors: list[str]) -> None:
+    zones = ids(model.get("trustZones"))
+    comps = ids(model.get("components"))
+    threats = ids(model.get("threats"))
+    mitigations = ids(model.get("mitigations"))
+
+    for c in model.get("components", []):
+        parent = c.get("parent", {})
+        tz, pc = parent.get("trustZone"), parent.get("component")
+        if tz and tz not in zones:
+            errors.append(f"[ref] component {c.get('id')}: unknown trustZone '{tz}'")
+        if pc and pc not in comps:
+            errors.append(f"[ref] component {c.get('id')}: unknown parent component '{pc}'")
+        for t in c.get("threats", []):
+            if t.get("threat") not in threats:
+                errors.append(f"[ref] component {c.get('id')}: unknown threat '{t.get('threat')}'")
+            for m in t.get("mitigations", []):
+                if m.get("mitigation") not in mitigations:
+                    errors.append(
+                        f"[ref] component {c.get('id')}: unknown mitigation '{m.get('mitigation')}'"
+                    )
+
+    for d in model.get("dataflows", []):
+        for endpoint in ("source", "destination"):
+            if d.get(endpoint) not in comps:
+                errors.append(
+                    f"[ref] dataflow {d.get('id')}: unknown {endpoint} '{d.get(endpoint)}'"
+                )
+
+    # Coverage hints (warnings, not failures) — surfaced but don't fail the build.
+    referenced_threats = {
+        t["threat"]
+        for c in model.get("components", [])
+        for t in c.get("threats", [])
+        if "threat" in t
+    }
+    for orphan in sorted(threats - referenced_threats):
+        print(f"WARN: threat '{orphan}' is defined but not attached to any component")
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_MODEL
+    if not path.exists():
+        sys.exit(f"ERROR: model not found: {path}")
+    model = load_yaml(path)
+
+    errors: list[str] = []
+    schema_validate(model, errors)
+    ref_validate(model, errors)
+
+    if errors:
+        print(f"\nFAILED — {len(errors)} problem(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print(f"OK — {path.name} is valid "
+          f"({len(model.get('components', []))} components, "
+          f"{len(model.get('threats', []))} threats, "
+          f"{len(model.get('mitigations', []))} mitigations).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds a version-controlled, **machine-readable threat model** for the 4.x line under `threat-model/`, in [Open Threat Model (OTM) 0.2.0](https://github.com/iriusrisk/OpenThreatModel) format. Draft for dev review before proposing upstream.

## Why

Security assumptions currently live in prose/wikis and drift. A model-as-data file can be reviewed in PRs, diffed over time, and validated in CI.

## Contents

- **`accumulo.otm.yaml`** — whole-system skeleton: trust zones (client, operator, cluster, ZooKeeper, HDFS), components (Manager, TabletServer, ScanServer, Compactor, GC, Monitor, ZooKeeper, HDFS), dataflows, and a representative STRIDE threat/mitigation set cross-referenced per component with an implementation `state`.
- **`accumulo.otm.schema.json`** — JSON Schema (Draft 2020-12) for the OTM subset used here.
- **`validate.py`** — JSON Schema validation **plus** referential-integrity checks (dangling threat/mitigation/component refs, dataflow endpoints) that a schema can't express.
- **`README.md`** — rationale, structure, how to validate/extend.
- **`pom.xml`** — excludes `threat-model/*.json` from Apache RAT (JSON can't carry a license-header comment).

## Validate

```bash
python3 -m pip install pyyaml jsonschema
python3 threat-model/validate.py
```

## Status / scope

This is a **skeleton**, not a security audit or completeness guarantee — intended to be extended per-subsystem (RPC/auth, delegation tokens, column visibility, crypto, FATE). Feedback welcome on format choice (OTM vs Threagile/pytm), threat coverage, and risk scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)